### PR TITLE
Upgrade to Kafka based on scala 2.11 and adjust our release name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,13 @@
 	</parent>
 
 	<properties>
-		<kafka.version.major>2.11</kafka.version.major>
-		<kafka.version.minor>0.10.0.1</kafka.version.minor>
+		<scala.version>2.11</scala.version>
+		<kafka.version>0.10.0.1</kafka.version>
 	</properties>
 	
 	<groupId>com.ibm.cloudant</groupId>
 	<artifactId>kafka-connect-cloudant</artifactId>
-	<version>${kafka.version.major}-${kafka.version.minor}</version>
+	<version>${kafka.version}</version>
 	<name>kafka-connect-cloudant</name>
 	<description>Kafka Connect Cloudant connector</description>
 
@@ -46,14 +46,14 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
-			<artifactId>kafka_${kafka.version.major}</artifactId>
-			<version>${kafka.version.minor}</version>
+			<artifactId>kafka_${scala.version}</artifactId>
+			<version>${kafka.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>connect-api</artifactId>
-			<version>${kafka.version.minor}</version>
+			<version>${kafka.version}</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -7,9 +7,14 @@
 		<version>18</version>
 	</parent>
 
+	<properties>
+		<kafka.version.major>2.11</kafka.version.major>
+		<kafka.version.minor>0.10.0.1</kafka.version.minor>
+	</properties>
+	
 	<groupId>com.ibm.cloudant</groupId>
 	<artifactId>kafka-connect-cloudant</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>${kafka.version.major}-${kafka.version.minor}</version>
 	<name>kafka-connect-cloudant</name>
 	<description>Kafka Connect Cloudant connector</description>
 
@@ -41,14 +46,14 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
-			<artifactId>kafka_2.10</artifactId>
-			<version>0.10.1.0</version>
+			<artifactId>kafka_${kafka.version.major}</artifactId>
+			<version>${kafka.version.minor}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>connect-api</artifactId>
-			<version>0.10.1.0</version>
+			<version>${kafka.version.minor}</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
MessageHub deploys Kafka 0.10.0.1 as base and we need a release of the connector that works for Kafka 0.10.0.1 (not 0.10.1.0)

This commit does 2 things:

- update our dependency from Kafka 0.10.1 to Kafka 0.10.0.1 (using a variable for the version dependency)
- change our .jar name to align with the Kafka version (using the same version variable)

As a result of this change we will build 
`kafka-connect-cloudant-0.10.0.1.jar`and `kafka-connect-cloudant-0.10.0.1-jar-with-dependencies.jar` accordingly

The branch should merge with `master` while we can break off a release for the (newer) version 0.10.1 already.