### PR TITLE
Update: Add Parameter “replicate” for setting guid_schema and kafka_schema #23 

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ cloudant.db.username|\<username\>|YES|None|The Cloudant username to use for auth
 cloudant.db.password|\<password\>|YES|None|The Cloudant password to use for authentication.
 tasks.max|5|NO|1|The number of concurrent threads to use for parallel bulk insert into Cloudant.
 batch.size|400|NO|1000|The maximum number of documents to commit with a single bulk insert.
-guid.schema|kafka|NO|kafka|The used schema to create ids for the Cloundant objects. Type of schemas: kafka [\<topic-name\>\_\<partition\>\_\<offset>\_\<sourceCloudantObjectId\>] or [\<sourceCloudantObjectId\>] 
+replication|false|NO|false|Managed object schema in sink database <br>*true: duplicate objects from source <br>false: adjust objects from source (\_id = [\<topic-name\>\_\<partition\>\_\<offset>\_\<sourceCloudantObjectId\>], kc.schema = Kafka value schema)*
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ cloudant.db.username|\<username\>|YES|None|The Cloudant username to use for auth
 cloudant.db.password|\<password\>|YES|None|The Cloudant password to use for authentication.
 tasks.max|5|NO|1|The number of concurrent threads to use for parallel bulk insert into Cloudant.
 batch.size|400|NO|1000|The maximum number of documents to commit with a single bulk insert.
-replication|false|NO|false|Managed object schema in sink database <br>*true: duplicate objects from source <br>false: adjust objects from source (\_id = [\<topic-name\>\_\<partition\>\_\<offset>\_\<sourceCloudantObjectId\>], kc.schema = Kafka value schema)*
+replication|false|NO|false|Managed object schema in sink database <br>*true: duplicate objects from source <br>false: adjust objects from source (\_id = [\<topic-name\>\_\<partition\>\_\<offset>\_\<sourceCloudantObjectId\>], kc\_schema = Kafka value schema)*
 
 ## Usage
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	
 	<groupId>com.ibm.cloudant</groupId>
 	<artifactId>kafka-connect-cloudant</artifactId>
-	<version>2017-05-10</version>
+	<version>2017-05-15</version>
 	<name>kafka-connect-cloudant</name>
 	<description>Kafka Connect Cloudant connector</description>
 

--- a/src/main/java/com/ibm/cloudant/kafka/common/InterfaceConst.java
+++ b/src/main/java/com/ibm/cloudant/kafka/common/InterfaceConst.java
@@ -31,5 +31,5 @@ public class InterfaceConst {
 	
 	public final static String REPLICATION = "replication";	
 	public final static Boolean DEFAULT_REPLICATION = false;
-	public final static String KC_SCHEMA = "kcschema";
+	public final static String KC_SCHEMA = "kc.schema";
 }

--- a/src/main/java/com/ibm/cloudant/kafka/common/InterfaceConst.java
+++ b/src/main/java/com/ibm/cloudant/kafka/common/InterfaceConst.java
@@ -28,13 +28,8 @@ public class InterfaceConst {
 	public final static String TASKS_MAX = "tasks.max";
 	public final static String TASK_NUMBER = "task.number";
 	public final static String BATCH_SIZE = "batch.size";
-	public final static String KC_SCHEMA = "kcschema";
-
-	public final static String GUID_SCHEMA = "guid.schema";	
 	
-	public static final String DEFAULT_GUID_SETTING = InterfaceConst.GUID_SETTING.KAFKA.name();	
-	public enum GUID_SETTING {
-		KAFKA, CLOUDANT
-	};
-
+	public final static String REPLICATION = "replication";	
+	public final static Boolean DEFAULT_REPLICATION = false;
+	public final static String KC_SCHEMA = "kcschema";
 }

--- a/src/main/java/com/ibm/cloudant/kafka/common/InterfaceConst.java
+++ b/src/main/java/com/ibm/cloudant/kafka/common/InterfaceConst.java
@@ -31,5 +31,5 @@ public class InterfaceConst {
 	
 	public final static String REPLICATION = "replication";	
 	public final static Boolean DEFAULT_REPLICATION = false;
-	public final static String KC_SCHEMA = "kc.schema";
+	public final static String KC_SCHEMA = "kc_schema";
 }

--- a/src/main/java/com/ibm/cloudant/kafka/connect/CloudantSinkTask.java
+++ b/src/main/java/com/ibm/cloudant/kafka/connect/CloudantSinkTask.java
@@ -74,7 +74,7 @@ public class CloudantSinkTask extends SinkTask {
 			if(jsonRecord.has(CloudantConst.CLOUDANT_DOC_ID)){			
 				if(replication == false) {
 					//Add archive schema from SinkRecord when available
-					jsonRecord.put(InterfaceConst.KC_SCHEMA, record.keySchema());
+					jsonRecord.put(InterfaceConst.KC_SCHEMA, record.valueSchema());
 					
 					//Create object id from kafka
 					jsonRecord.put(CloudantConst.CLOUDANT_DOC_ID, 

--- a/src/main/java/com/ibm/cloudant/kafka/connect/CloudantSinkTask.java
+++ b/src/main/java/com/ibm/cloudant/kafka/connect/CloudantSinkTask.java
@@ -48,7 +48,7 @@ public class CloudantSinkTask extends SinkTask {
 	private String password = null;
 	
 	private static int batch_size = 0;
-	private String guid_schema = null;
+	private Boolean replication;
 	private JSONArray jsonArray = new JSONArray();
 		
 	public String version() {
@@ -71,29 +71,28 @@ public class CloudantSinkTask extends SinkTask {
 				jsonRecord.remove(CloudantConst.CLOUDANT_REV);
 			}
 			
-			if(jsonRecord.has(CloudantConst.CLOUDANT_DOC_ID)){
-				//Add archive schema from SinkRecord when available
-				if(record.keySchema() != null) {
+			if(jsonRecord.has(CloudantConst.CLOUDANT_DOC_ID)){			
+				if(replication == false) {
+					//Add archive schema from SinkRecord when available
 					jsonRecord.put(InterfaceConst.KC_SCHEMA, record.keySchema());
-				}
-				
-				if(guid_schema.equalsIgnoreCase(InterfaceConst.GUID_SETTING.KAFKA.name())) {				
+					
+					//Create object id from kafka
 					jsonRecord.put(CloudantConst.CLOUDANT_DOC_ID, 
 							record.topic() + "_" + 
 							record.kafkaPartition().toString() + "_" + 
 							Long.toString(record.kafkaOffset()) + "_" + 
 							jsonRecord.get(CloudantConst.CLOUDANT_DOC_ID));	
 				}
-				else if (guid_schema.equalsIgnoreCase(InterfaceConst.GUID_SETTING.CLOUDANT.name())) {
-					// Do Nothing => Mirror from Cloundant Obj
-				}
-				else {
+				//OPTION B: IF replication == true => Do Nothing => Create mirror from Cloudant object
+				
+				//OPTION C (not implemented): generate new id with  cloudant 
+				/*else {
 					LOG.info(MessageKey.GUID_SCHEMA + ": " + guid_schema);
 					LOG.warn(CloudantConst.CLOUDANT_DOC_ID + "from source database will removed");
 					
 					//remove Cloudant _id
 					jsonRecord.remove(CloudantConst.CLOUDANT_DOC_ID);
-				}
+				}*/
 			}					
 			jsonArray.put(jsonRecord);
 			
@@ -122,9 +121,9 @@ public class CloudantSinkTask extends SinkTask {
 			userName = config.getString(InterfaceConst.USER_NAME);
             password = config.getPassword(InterfaceConst.PASSWORD).value();
 			
-			batch_size = config.getInt(InterfaceConst.BATCH_SIZE)==null ? CloudantConst.DEFAULT_BATCH_SIZE : config.getInt(InterfaceConst.BATCH_SIZE);
-			guid_schema = config.getString(InterfaceConst.GUID_SCHEMA) == null ? InterfaceConst.DEFAULT_GUID_SETTING : config.getString(InterfaceConst.GUID_SCHEMA); 
-
+			batch_size = config.getInt(InterfaceConst.BATCH_SIZE)==null ? CloudantConst.DEFAULT_BATCH_SIZE : config.getInt(InterfaceConst.BATCH_SIZE);			
+			replication = config.getBoolean(InterfaceConst.REPLICATION) == null ? InterfaceConst.DEFAULT_REPLICATION : config.getBoolean(InterfaceConst.REPLICATION); 
+						
 		} catch (ConfigException e) {
 			throw new ConnectException(ResourceBundleUtil.get(MessageKey.CONFIGURATION_EXCEPTION), e);
 		}

--- a/src/main/java/com/ibm/cloudant/kafka/connect/CloudantSinkTaskConfig.java
+++ b/src/main/java/com/ibm/cloudant/kafka/connect/CloudantSinkTaskConfig.java
@@ -29,8 +29,8 @@ public class CloudantSinkTaskConfig extends CloudantSinkConnectorConfig {
 	static org.apache.kafka.common.config.ConfigDef config = baseConfigDef()
 		      .define(InterfaceConst.BATCH_SIZE, Type.INT, CloudantConst.DEFAULT_BATCH_SIZE,
 		    		  Importance.LOW, InterfaceConst.BATCH_SIZE)
-		      .define(InterfaceConst.GUID_SCHEMA, Type.STRING, InterfaceConst.DEFAULT_GUID_SETTING,
-		    		  Importance.LOW, InterfaceConst.GUID_SCHEMA);
+		      .define(InterfaceConst.REPLICATION, Type.BOOLEAN, InterfaceConst.DEFAULT_REPLICATION,
+		    		  Importance.LOW, InterfaceConst.REPLICATION);
 	
 	public CloudantSinkTaskConfig(Map<String, String> originals) {
 		super(config, originals);

--- a/src/test/java/com/ibm/cloudant/kafka/connect/CloudantSinkConnectorTest.java
+++ b/src/test/java/com/ibm/cloudant/kafka/connect/CloudantSinkConnectorTest.java
@@ -63,7 +63,7 @@ public class CloudantSinkConnectorTest extends TestCase {
 
         targetProperties.put(InterfaceConst.TOPIC, testProperties.getProperty(InterfaceConst.TOPIC));
         
-        targetProperties.put(InterfaceConst.GUID_SCHEMA, testProperties.getProperty(InterfaceConst.GUID_SCHEMA));
+        targetProperties.put(InterfaceConst.REPLICATION, testProperties.getProperty(InterfaceConst.REPLICATION));
 	}
 
 

--- a/src/test/java/com/ibm/cloudant/kafka/connect/CloudantSinkTaskTest.java
+++ b/src/test/java/com/ibm/cloudant/kafka/connect/CloudantSinkTaskTest.java
@@ -15,7 +15,6 @@
 *******************************************************************************/
 package com.ibm.cloudant.kafka.connect;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileReader;
 import java.util.ArrayList;
@@ -32,7 +31,6 @@ import org.json.JSONArray;
 
 import com.cloudant.client.api.Database;
 import com.cloudant.client.api.model.ChangesResult;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.ibm.cloudant.kafka.common.InterfaceConst;
@@ -48,10 +46,12 @@ import junit.framework.TestCase;
 public class CloudantSinkTaskTest extends TestCase {
 
 	private CloudantSinkTask task;
-    private ByteArrayOutputStream os;
 	private HashMap<String, String> targetProperties;
 	
 	JSONArray data = null;
+	
+	JsonParser parser;
+	JsonObject doc1, doc2, doc3;
 	
 	Properties testProperties;
 	
@@ -65,7 +65,6 @@ public class CloudantSinkTaskTest extends TestCase {
 		testProperties.load(new FileReader(new File("src/test/resources/test.properties")));
 		
 		task = new CloudantSinkTask();
-		os = new ByteArrayOutputStream();
 	      
 		targetProperties = new HashMap<String, String>();
 		
@@ -78,14 +77,73 @@ public class CloudantSinkTaskTest extends TestCase {
     	  
 		targetProperties.put(InterfaceConst.TOPIC, testProperties.getProperty(InterfaceConst.TOPIC));
 		
-		targetProperties.put(InterfaceConst.REPLICATION, testProperties.getProperty(InterfaceConst.REPLICATION));		
+		//Test objects
+		parser = new JsonParser();
+		doc1 = parser.parse("{\"_id\":\"doc1\","
+				+ "\"number\":1,"
+				+ "\"key\":\"value1\"}").getAsJsonObject();
+		
+		doc2 = parser.parse("{\"_id\":\"doc2\","
+				+ "\"number\":2,"
+				+ "\"key\":\"value2\"}").getAsJsonObject();
+		
+		doc3 = parser.parse("{\"_id\":\"doc3\","
+				+ "\"number\":3,"
+				+ "\"key\":\"value3\"}").getAsJsonObject();
 	}
 
 	/**
 	 * Test method for {@link com.ibm.cloudant.kafka.connect.CloudantSinkTask#put(java.util.Collection)}.
 	 */
-	public void testPutCollectionOfSinkRecord() {
+	public void testReplicateSinkRecordSchema() {
+		targetProperties.put(InterfaceConst.REPLICATION, "true");				
+		List<JsonObject> result = testPutCollectionOfSinkRecord();				
+				
+		//Test results
+		assertEquals(3, result.size());	
+		assertTrue(result.contains(doc1));
+		assertTrue(result.contains(doc2));
+		assertTrue(result.contains(doc3));
+	}
+	
+	/**
+	 * Test method for {@link com.ibm.cloudant.kafka.connect.CloudantSinkTask#put(java.util.Collection)}.
+	 */
+	public void testNonReplicateSinkRecordSchema() {
+		targetProperties.put(InterfaceConst.REPLICATION, "false");		
+		List<JsonObject> result = testPutCollectionOfSinkRecord();	
 		
+		//Add Information (id_schema, kcschema)
+		JsonObject kcschema = new JsonObject();
+		kcschema.addProperty("type", "STRING");
+		kcschema.addProperty("optional", false);		
+		
+		doc1.add("kcschema", kcschema);
+		doc1.addProperty("_id", 
+				targetProperties.get(InterfaceConst.TOPIC) + 
+				"_" + 0 + "_" + doc1.get("number") + 
+				"_" + doc1.get("_id").getAsString());	
+		
+		doc2.add("kcschema", kcschema);
+		doc2.addProperty("_id", 
+				targetProperties.get(InterfaceConst.TOPIC) + 
+				"_" + 0 + "_" + doc2.get("number") + 
+				"_" + doc2.get("_id").getAsString());
+		
+		doc3.add("kcschema", kcschema);
+		doc3.addProperty("_id", 
+				targetProperties.get(InterfaceConst.TOPIC) + 
+				"_" + 0 + "_" + doc3.get("number") + 
+				"_" + doc3.get("_id").getAsString());
+										
+		//Test results		
+		assertEquals(3, result.size());	
+		assertTrue(result.contains(doc1));
+		assertTrue(result.contains(doc2));
+		assertTrue(result.contains(doc3));
+	}
+		
+	public List<JsonObject> testPutCollectionOfSinkRecord() {	
 		// CLOUDANT
 		Database db = JavaCloudantUtil.getDBInst(
 				targetProperties.get(InterfaceConst.URL), 
@@ -101,33 +159,23 @@ public class CloudantSinkTaskTest extends TestCase {
 		// Emit 3 new documents
 		task.start(targetProperties);
 		
-		JsonParser parser = new JsonParser();
-
-		JsonObject doc1 = parser.parse("{\"_id\":\"doc1\","
-				+ "\"key\":\"value1\"}").getAsJsonObject();
-		
 		task.put(Arrays.asList(
 				new SinkRecord(testProperties.getProperty(InterfaceConst.TOPIC), 0, 
-						null, null, Schema.STRING_SCHEMA, doc1, 1)));
+						null, null, Schema.STRING_SCHEMA, doc1, doc1.get("number").getAsLong())));
 		
 	/*	offsets.put(new TopicPartition(testProperties.getProperty(InterfaceConst.TOPIC), 0), 
 				new OffsetAndMetadata(1L));
 		*/
 		task.flush(offsets);
-
-		JsonObject doc2 = parser.parse("{\"_id\":\"doc2\","
-				+ "\"key\":\"value2\"}").getAsJsonObject();
-		
-		JsonObject doc3 = parser.parse("{\"_id\":\"doc3\","
-				+ "\"key\":\"value3\"}").getAsJsonObject();
 		
 		task.put(Arrays.asList(
 				new SinkRecord(testProperties.getProperty(InterfaceConst.TOPIC), 
-						0, null, null, Schema.STRING_SCHEMA,doc2.toString(), 2),
+						0, null, null, Schema.STRING_SCHEMA,doc2.toString(), doc2.get("number").getAsLong()),
 				
 				new SinkRecord(testProperties.getProperty(InterfaceConst.TOPIC), 
-						0, null, null, Schema.STRING_SCHEMA, doc3.toString(), 3)
-				));
+						0, null, null, Schema.STRING_SCHEMA, doc3.toString(), doc3.get("number").getAsLong())
+				));		
+		
 	/*	
 		offsets.put(new TopicPartition(testProperties.getProperty(InterfaceConst.TOPIC), 0), 
 				new OffsetAndMetadata(2L));
@@ -143,19 +191,15 @@ public class CloudantSinkTaskTest extends TestCase {
 				.includeDocs(true)
 				.getChanges();
 
-		 //process the ChangesResult
-		List<JsonElement> result = new ArrayList<JsonElement>();
-		
+		//process the ChangesResult			
+		List<JsonObject> result = new ArrayList<JsonObject>();
 		for (ChangesResult.Row row : changeResult.getResults()) {
-			 JsonElement key = row.getDoc().get("key");
-			 result.add(key);
+			 JsonObject doc = row.getDoc();
+			 doc.remove("_rev");
+			 result.add(doc);
 		}
-		 
-		assertEquals(3, result.size());
-	
-		assertTrue(result.contains(doc1.get("key")));
-		assertTrue(result.contains(doc2.get("key")));
-		assertTrue(result.contains(doc3.get("key")));
+		
+		return result;
 	}
 
 	/**

--- a/src/test/java/com/ibm/cloudant/kafka/connect/CloudantSinkTaskTest.java
+++ b/src/test/java/com/ibm/cloudant/kafka/connect/CloudantSinkTaskTest.java
@@ -118,19 +118,19 @@ public class CloudantSinkTaskTest extends TestCase {
 		kcschema.addProperty("type", "STRING");
 		kcschema.addProperty("optional", false);		
 		
-		doc1.add("kcschema", kcschema);
+		doc1.add(InterfaceConst.KC_SCHEMA, kcschema);
 		doc1.addProperty("_id", 
 				targetProperties.get(InterfaceConst.TOPIC) + 
 				"_" + 0 + "_" + doc1.get("number") + 
 				"_" + doc1.get("_id").getAsString());	
 		
-		doc2.add("kcschema", kcschema);
+		doc2.add(InterfaceConst.KC_SCHEMA, kcschema);
 		doc2.addProperty("_id", 
 				targetProperties.get(InterfaceConst.TOPIC) + 
 				"_" + 0 + "_" + doc2.get("number") + 
 				"_" + doc2.get("_id").getAsString());
 		
-		doc3.add("kcschema", kcschema);
+		doc3.add(InterfaceConst.KC_SCHEMA, kcschema);
 		doc3.addProperty("_id", 
 				targetProperties.get(InterfaceConst.TOPIC) + 
 				"_" + 0 + "_" + doc3.get("number") + 

--- a/src/test/java/com/ibm/cloudant/kafka/connect/CloudantSinkTaskTest.java
+++ b/src/test/java/com/ibm/cloudant/kafka/connect/CloudantSinkTaskTest.java
@@ -78,7 +78,7 @@ public class CloudantSinkTaskTest extends TestCase {
     	  
 		targetProperties.put(InterfaceConst.TOPIC, testProperties.getProperty(InterfaceConst.TOPIC));
 		
-		targetProperties.put(InterfaceConst.GUID_SCHEMA, testProperties.getProperty(InterfaceConst.GUID_SCHEMA));		
+		targetProperties.put(InterfaceConst.REPLICATION, testProperties.getProperty(InterfaceConst.REPLICATION));		
 	}
 
 	/**

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -13,5 +13,5 @@ batch.size=500
 # Topic name (for an existing topic)
 topics=test-topic
 
-# GUID schema (Options: kafka, cloudant)
-guid.schema=kafka
+# Replication Schema (default: false)
+replication=false


### PR DESCRIPTION
Add a new parameter “replicate” in the file connect-cloudant-sink.properties. The property handle the schema of the objects in the sink database. The new attribute “replicate” handle and replace the attributes guid_schema and kafka_schema.

If the property true the source object should be mirrored in the sink database. Therefore, the system using the guid_schema from the source object and don’t add the kafka_schema to the object.

If the property false the source object should be saved with additional information in the sink database. Therefore, the system create a new object id from kafka (#8) and add the kafka_schema from the SinkRecord (#9).