### PR TITLE
Schema opts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [NEW] Configuration option `cloudant.value.schema.struct` to send the Cloudant document message
+ with a `org.apache.kafka.connect.data.Struct` value schema instead of as a `String`.
 - [BREAKING CHANGE] Changed build tooling to Gradle.
 - [NOTE] Version number format. The kafka-connect-cloudant version is no longer identical
  to an Apache Kafka version. The Apache Kafka version is appended to the kafka-cloudant-connect

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ cloudant.db.password|\<password\>|YES|None|The Cloudant password to use for auth
 tasks.max|5|NO|1|The number of concurrent threads to use for parallel bulk insert into Cloudant.
 batch.size|400|NO|1000|The maximum number of documents to commit with a single bulk insert.
 replication|false|NO|false|Managed object schema in sink database <br>*true: duplicate objects from source <br>false: adjust objects from source (\_id = [\<topic-name\>\_\<partition\>\_\<offset>\_\<sourceCloudantObjectId\>], kc\_schema = Kafka value schema)*
+cloudant.value.schema.struct|false|NO|false| _EXPERIMENTAL_ Set to true to generate a `org.apache.kafka.connect.data.Schema.Type.STRUCT` schema and send the Cloudant document payload as a `org.apache.kafka.connect.data.Struct` using the schema instead of the default of a string of the JSON document content when using the Cloudant source connector.
 
 ## Usage
 

--- a/build.gradle
+++ b/build.gradle
@@ -160,7 +160,7 @@ uploadArchives {
 
 test {
     // Exclude the performance tests
-    exclude 'com/ibm/cloudant/kakfa/performance/**'
+    exclude 'com/ibm/cloudant/kafka/performance/**'
 }
 
 tasks.withType(Test) {

--- a/src/main/java/com/ibm/cloudant/kafka/common/InterfaceConst.java
+++ b/src/main/java/com/ibm/cloudant/kafka/common/InterfaceConst.java
@@ -1,18 +1,16 @@
-/*******************************************************************************
-* Copyright (c) 2016 IBM Corp.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*******************************************************************************/
+/*
+ * Copyright © 2016, 2018 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
 package com.ibm.cloudant.kafka.common;
 
 public class InterfaceConst {
@@ -36,4 +34,7 @@ public class InterfaceConst {
 	public final static String REPLICATION = "replication";	
 	public final static Boolean DEFAULT_REPLICATION = false;
 	public final static String KC_SCHEMA = "kc_schema";
+
+	// Whether to use a struct schema for the message values
+	public final static String USE_VALUE_SCHEMA_STRUCT = "cloudant.value.schema.struct";
 }

--- a/src/main/java/com/ibm/cloudant/kafka/common/MessageKey.java
+++ b/src/main/java/com/ibm/cloudant/kafka/common/MessageKey.java
@@ -1,18 +1,16 @@
-/*******************************************************************************
-* Copyright (c) 2016 IBM Corp.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*******************************************************************************/
+/*
+ * Copyright © 2016, 2018 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
 package com.ibm.cloudant.kafka.common;
 
 public class MessageKey {
@@ -35,6 +33,9 @@ public class MessageKey {
 	
 	public static final String KAFKA_TOPIC_LIST_DOC = "KafkaTopicListDoc";
 	public static final String KAFKA_TOPIC_LIST_DISP = "KafkaTopicListDisp";
-	
+
+	public static final String CLOUDANT_STRUCT_SCHEMA_DISP = "CloudantSchemaDisp";
+	public static final String CLOUDANT_STRUCT_SCHEMA_DOC = "CloudantSchemaDoc";
+
 	public static final String GUID_SCHEMA = "GuidSchema";
 }

--- a/src/main/java/com/ibm/cloudant/kafka/connect/CloudantSourceConnectorConfig.java
+++ b/src/main/java/com/ibm/cloudant/kafka/connect/CloudantSourceConnectorConfig.java
@@ -15,7 +15,9 @@
 *******************************************************************************/
 package com.ibm.cloudant.kafka.connect;
 
-import java.util.Map;
+import com.ibm.cloudant.kafka.common.InterfaceConst;
+import com.ibm.cloudant.kafka.common.MessageKey;
+import com.ibm.cloudant.kafka.common.utils.ResourceBundleUtil;
 
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
@@ -24,9 +26,7 @@ import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Width;
 import org.apache.log4j.Logger;
 
-import com.ibm.cloudant.kafka.common.InterfaceConst;
-import com.ibm.cloudant.kafka.common.MessageKey;
-import com.ibm.cloudant.kafka.common.utils.ResourceBundleUtil;
+import java.util.Map;
 
 public class CloudantSourceConnectorConfig extends AbstractConfig {
 	
@@ -34,41 +34,47 @@ public class CloudantSourceConnectorConfig extends AbstractConfig {
 
 	public static final String DATABASE_GROUP = "Database";
 	public static final String CLOUDANT_LAST_SEQ_NUM_DEFAULT = null;
-	
 	public static final ConfigDef CONFIG_DEF = baseConfigDef();
 
 	public static ConfigDef baseConfigDef() {
-		
 		return new ConfigDef()
-				  
-				  // Cloudant URL
-				  .define(InterfaceConst.URL, Type.STRING, Importance.HIGH, 
-						  ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_URL_DOC), 
-						  DATABASE_GROUP, 1, Width.LONG,
-						  ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_URL_DISP))
-				  // Cloudant Username
-				  .define(InterfaceConst.USER_NAME, Type.STRING, Importance.HIGH, 
-						  ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_USR_DOC), 
-						  DATABASE_GROUP, 1, Width.LONG,
-						  ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_USR_DISP))
-				  // Cloudant Password
-				  .define(InterfaceConst.PASSWORD, Type.PASSWORD, Importance.HIGH, 
-						  ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_PWD_DOC), 
-						  DATABASE_GROUP, 1, Width.LONG,
-						  ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_PWD_DISP))
-				  // Cloudant last change sequence
-				  .define(InterfaceConst.LAST_CHANGE_SEQ, Type.STRING, CLOUDANT_LAST_SEQ_NUM_DEFAULT, 
-						  Importance.LOW, 
-						  ResourceBundleUtil.get(MessageKey.CLOUDANT_LAST_SEQ_NUM_DOC), 
-						  DATABASE_GROUP, 1, Width.LONG,
-						  ResourceBundleUtil.get(MessageKey.CLOUDANT_LAST_SEQ_NUM_DOC))
-				  
-				  // Kafka topic
-				  .define(InterfaceConst.TOPIC, Type.LIST,
-						  Importance.HIGH, 
-						  ResourceBundleUtil.get(MessageKey.KAFKA_TOPIC_LIST_DOC), 
-						  DATABASE_GROUP, 1, Width.LONG,
-						  ResourceBundleUtil.get(MessageKey.KAFKA_TOPIC_LIST_DISP));
+
+				// Cloudant URL
+				.define(InterfaceConst.URL, Type.STRING, Importance.HIGH,
+						ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_URL_DOC),
+						DATABASE_GROUP, 1, Width.LONG,
+						ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_URL_DISP))
+				// Cloudant Username
+				.define(InterfaceConst.USER_NAME, Type.STRING, Importance.HIGH,
+						ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_USR_DOC),
+						DATABASE_GROUP, 1, Width.LONG,
+						ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_USR_DISP))
+				// Cloudant Password
+				.define(InterfaceConst.PASSWORD, Type.PASSWORD, Importance.HIGH,
+						ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_PWD_DOC),
+						DATABASE_GROUP, 1, Width.LONG,
+						ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_PWD_DISP))
+				// Cloudant last change sequence
+				.define(InterfaceConst.LAST_CHANGE_SEQ, Type.STRING, CLOUDANT_LAST_SEQ_NUM_DEFAULT,
+						Importance.LOW,
+						ResourceBundleUtil.get(MessageKey.CLOUDANT_LAST_SEQ_NUM_DOC),
+						DATABASE_GROUP, 1, Width.LONG,
+						ResourceBundleUtil.get(MessageKey.CLOUDANT_LAST_SEQ_NUM_DOC))
+
+				// Kafka topic
+				.define(InterfaceConst.TOPIC, Type.LIST,
+						Importance.HIGH,
+						ResourceBundleUtil.get(MessageKey.KAFKA_TOPIC_LIST_DOC),
+						DATABASE_GROUP, 1, Width.LONG,
+						ResourceBundleUtil.get(MessageKey.KAFKA_TOPIC_LIST_DISP))
+
+				// Whether to generate a struct Schema
+				.define(InterfaceConst.USE_VALUE_SCHEMA_STRUCT, Type.BOOLEAN,
+						false,
+						Importance.HIGH,
+						ResourceBundleUtil.get(MessageKey.CLOUDANT_STRUCT_SCHEMA_DOC),
+						DATABASE_GROUP, 1, Width.NONE,
+						ResourceBundleUtil.get(MessageKey.CLOUDANT_STRUCT_SCHEMA_DISP));
 	}
 	
 	public CloudantSourceConnectorConfig(Map<String, String> originals) {

--- a/src/main/java/com/ibm/cloudant/kafka/schema/JsonStruct.java
+++ b/src/main/java/com/ibm/cloudant/kafka/schema/JsonStruct.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2018 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.ibm.cloudant.kafka.schema;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class JsonStruct {
+
+    public static Schema jsonObjectToSchema(JsonObject o) {
+        SchemaBuilder sb = SchemaBuilder.struct();
+        for (Map.Entry<String, JsonElement> field : o.entrySet()) {
+            sb.field(field.getKey(), jsonElementToSchema(field.getValue()));
+        }
+        sb.optional();
+        return sb.build();
+    }
+
+    public static Struct jsonObjectToStruct(JsonObject o, Schema schema) {
+        Struct struct = new Struct(schema);
+        for (Field f : schema.fields()) {
+            struct.put(f, fromJsonElement(o.get(f.name()), f.schema()));
+        }
+        return struct;
+    }
+
+    private static Object fromJsonElement(JsonElement e, Schema s) {
+        switch (s.type()) {
+            case STRUCT:
+                return jsonObjectToStruct(e.getAsJsonObject(), s);
+            case ARRAY:
+                JsonArray jsonArray = e.getAsJsonArray();
+                List array = new ArrayList(jsonArray.size());
+                for (JsonElement arrayElement : jsonArray) {
+                    array.add(fromJsonElement(arrayElement, s.valueSchema()));
+                }
+                return array;
+            case STRING:
+                // We always map JsonNull to an optional string, so we need to check again if it
+                // is a JSON null before we try to get it
+                if (e.isJsonNull()) {
+                    return null;
+                } else {
+                    return e.getAsString();
+                }
+            case BOOLEAN:
+                return e.getAsBoolean();
+            case FLOAT64:
+                return e.getAsDouble();
+            default:
+                return null;
+        }
+    }
+
+    private static Schema jsonArrayToSchema(JsonArray a) {
+        if (a.size() > 0) {
+            // Can't do mixed type arrays in Kafka
+            // Base the array type on the first element
+            return SchemaBuilder.array(jsonElementToSchema(a.get(0))).optional().build();
+        } else {
+            // Treat an empty array as a String type
+            return SchemaBuilder.array(SchemaBuilder.OPTIONAL_STRING_SCHEMA).optional().build();
+        }
+    }
+
+    private static Schema jsonPrimitiveToSchema(JsonPrimitive p) {
+        if (p.isBoolean()) {
+            return Schema.OPTIONAL_BOOLEAN_SCHEMA;
+        } else if (p.isNumber()) {
+            return Schema.OPTIONAL_FLOAT64_SCHEMA;
+        } else {
+            // String
+            return Schema.OPTIONAL_STRING_SCHEMA;
+        }
+    }
+
+    static Schema jsonElementToSchema(JsonElement e) {
+        if (e.isJsonNull()) {
+            return Schema.OPTIONAL_STRING_SCHEMA;
+        } else if (e.isJsonPrimitive()) {
+            return jsonPrimitiveToSchema(e.getAsJsonPrimitive());
+        } else if (e.isJsonArray()) {
+            return jsonArrayToSchema(e.getAsJsonArray());
+        } else {
+            // Object
+            return jsonObjectToSchema(e.getAsJsonObject());
+        }
+    }
+
+}

--- a/src/main/resources/message_en_US.properties
+++ b/src/main/resources/message_en_US.properties
@@ -28,3 +28,15 @@ KafkaTopicListDisp = Kafka topics
 GuidSchema = GUID Schema is unknown
 
 CloudantLimitation = Error retrieving server response
+
+CloudantSchemaDisp = Enable struct schema generation (experimental)
+CloudantSchemaDoc = True to enable generation of a struct schema with each JSON document.\
+  The struct schema will include all the fields found in the document with the following mappings:\
+  string -> Schema.Type.STRING\
+  number -> Schema.Type.FLOAT64\
+  object -> Schema.Type.STRUCT\
+  array -> Schema.Type.ARRAY (note limited to single element type, based on the first element, \
+  empty arrays are treated as String arrays)\
+  boolean -> Schema.Type.BOOLEAN\
+  null -> Schema.Type.STRING\
+  Note that all fields are marked as optional in the generated STRUCT schema for a document.

--- a/src/test/java/com/ibm/cloudant/kafka/connect/CloudantSinkConnectorTest.java
+++ b/src/test/java/com/ibm/cloudant/kafka/connect/CloudantSinkConnectorTest.java
@@ -15,7 +15,7 @@ package com.ibm.cloudant.kafka.connect;
 
 
 import com.ibm.cloudant.kafka.common.InterfaceConst;
-import com.ibm.cloudant.kakfa.connect.utils.ConnectorUtils;
+import com.ibm.cloudant.kafka.connect.utils.ConnectorUtils;
 
 import junit.framework.TestCase;
 

--- a/src/test/java/com/ibm/cloudant/kafka/connect/CloudantSinkTaskTest.java
+++ b/src/test/java/com/ibm/cloudant/kafka/connect/CloudantSinkTaskTest.java
@@ -19,8 +19,8 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.ibm.cloudant.kafka.common.InterfaceConst;
 import com.ibm.cloudant.kafka.common.utils.JavaCloudantUtil;
-import com.ibm.cloudant.kakfa.connect.utils.CloudantDbUtils;
-import com.ibm.cloudant.kakfa.connect.utils.ConnectorUtils;
+import com.ibm.cloudant.kafka.connect.utils.CloudantDbUtils;
+import com.ibm.cloudant.kafka.connect.utils.ConnectorUtils;
 
 import junit.framework.TestCase;
 

--- a/src/test/java/com/ibm/cloudant/kafka/connect/CloudantSourceConnectorTest.java
+++ b/src/test/java/com/ibm/cloudant/kafka/connect/CloudantSourceConnectorTest.java
@@ -14,7 +14,7 @@
 package com.ibm.cloudant.kafka.connect;
 
 import com.ibm.cloudant.kafka.common.InterfaceConst;
-import com.ibm.cloudant.kakfa.connect.utils.ConnectorUtils;
+import com.ibm.cloudant.kafka.connect.utils.ConnectorUtils;
 
 import junit.framework.TestCase;
 

--- a/src/test/java/com/ibm/cloudant/kafka/connect/CloudantSourceConnectorTest.java
+++ b/src/test/java/com/ibm/cloudant/kafka/connect/CloudantSourceConnectorTest.java
@@ -100,6 +100,9 @@ public class CloudantSourceConnectorTest extends TestCase {
         Assert.assertEquals(sourceProperties.get(InterfaceConst.BATCH_SIZE), taskConfigs.get(0)
                 .get(InterfaceConst.BATCH_SIZE));
 
+        Assert.assertEquals(sourceProperties.get(InterfaceConst.USE_VALUE_SCHEMA_STRUCT), taskConfigs.get(0)
+                .get(InterfaceConst.USE_VALUE_SCHEMA_STRUCT));
+
         PowerMock.verifyAll();
     }
 }

--- a/src/test/java/com/ibm/cloudant/kafka/connect/CloudantSourceTaskTest.java
+++ b/src/test/java/com/ibm/cloudant/kafka/connect/CloudantSourceTaskTest.java
@@ -21,6 +21,7 @@ import com.ibm.cloudant.kafka.connect.utils.ConnectorUtils;
 
 import junit.framework.TestCase;
 
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -115,6 +116,30 @@ public class CloudantSourceTaskTest extends TestCase {
         // (even though database has 999 + 20 documents now)
         records2 = task.poll();
         assertEquals(new_changes, records2.size());
+    }
+
+    public void testStructMessage() throws InterruptedException {
+        PowerMock.replayAll();
+
+        // Use the struct message format
+        sourceProperties.put(InterfaceConst.USE_VALUE_SCHEMA_STRUCT, "true");
+
+        // Run the task and process all documents currently in the _changes feed
+        task.start(sourceProperties);
+        List<SourceRecord> records = task.poll();
+        assertTrue(records.size() > 0);
+        assertEquals(999, records.size());
+
+        // Inspect the first record and make sure it is a struct
+        SourceRecord firstRecord = records.get(0);
+
+        assertEquals("The key schema should be a string", Schema.STRING_SCHEMA, firstRecord.keySchema());
+
+        Schema schema = firstRecord.valueSchema();
+
+        // The default is a String schema, so it should not be that with the option enabled
+        assertEquals("The value schema type should be a struct schema", Schema.Type.STRUCT, schema.type());
+        assertTrue("There should be multiple fields in the schema", schema.fields().size() > 1);
     }
 
     /**

--- a/src/test/java/com/ibm/cloudant/kafka/connect/CloudantSourceTaskTest.java
+++ b/src/test/java/com/ibm/cloudant/kafka/connect/CloudantSourceTaskTest.java
@@ -16,8 +16,8 @@ package com.ibm.cloudant.kafka.connect;
 import com.ibm.cloudant.kafka.common.CloudantConst;
 import com.ibm.cloudant.kafka.common.InterfaceConst;
 import com.ibm.cloudant.kafka.common.utils.JavaCloudantUtil;
-import com.ibm.cloudant.kakfa.connect.utils.CloudantDbUtils;
-import com.ibm.cloudant.kakfa.connect.utils.ConnectorUtils;
+import com.ibm.cloudant.kafka.connect.utils.CloudantDbUtils;
+import com.ibm.cloudant.kafka.connect.utils.ConnectorUtils;
 
 import junit.framework.TestCase;
 

--- a/src/test/java/com/ibm/cloudant/kafka/connect/utils/CloudantDbUtils.java
+++ b/src/test/java/com/ibm/cloudant/kafka/connect/utils/CloudantDbUtils.java
@@ -1,4 +1,17 @@
-package com.ibm.cloudant.kakfa.connect.utils;
+/*
+ * Copyright © 2016, 2018 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.ibm.cloudant.kafka.connect.utils;
 
 import com.cloudant.client.api.ClientBuilder;
 import com.cloudant.client.api.CloudantClient;

--- a/src/test/java/com/ibm/cloudant/kafka/connect/utils/ConnectorUtils.java
+++ b/src/test/java/com/ibm/cloudant/kafka/connect/utils/ConnectorUtils.java
@@ -162,12 +162,19 @@ public class ConnectorUtils {
                     .URL));
             connectorProperties.put(InterfaceConst.USER_NAME, testProperties.getProperty
                     (InterfaceConst.USER_NAME));
-            connectorProperties.put(InterfaceConst.PASSWORD, testProperties.getProperty(InterfaceConst.PASSWORD));
+            connectorProperties.put(InterfaceConst.PASSWORD, testProperties.getProperty
+                    (InterfaceConst.PASSWORD));
         }
 
         // Topic and tasks max are common to both configurations
-        connectorProperties.put(InterfaceConst.TOPIC, testProperties.getProperty(InterfaceConst.TOPIC));
-        connectorProperties.put(InterfaceConst.TASKS_MAX, testProperties.getProperty(InterfaceConst.TASKS_MAX));
+        connectorProperties.put(InterfaceConst.TOPIC, testProperties.getProperty(InterfaceConst
+                .TOPIC));
+        connectorProperties.put(InterfaceConst.TASKS_MAX, testProperties.getProperty
+                (InterfaceConst.TASKS_MAX));
+
+        // Schema options
+        connectorProperties.put(InterfaceConst.USE_VALUE_SCHEMA_STRUCT, testProperties
+                .getProperty(InterfaceConst.USE_VALUE_SCHEMA_STRUCT));
 
         // Add the performance URL
         connectorProperties.put(PERFORMANCE_URL, testProperties.getProperty(PERFORMANCE_URL));

--- a/src/test/java/com/ibm/cloudant/kafka/connect/utils/ConnectorUtils.java
+++ b/src/test/java/com/ibm/cloudant/kafka/connect/utils/ConnectorUtils.java
@@ -11,7 +11,7 @@
  * either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-package com.ibm.cloudant.kakfa.connect.utils;
+package com.ibm.cloudant.kafka.connect.utils;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;

--- a/src/test/java/com/ibm/cloudant/kafka/performance/CloudantSinkPerformanceTest.java
+++ b/src/test/java/com/ibm/cloudant/kafka/performance/CloudantSinkPerformanceTest.java
@@ -11,7 +11,7 @@
  * either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-package com.ibm.cloudant.kakfa.performance;
+package com.ibm.cloudant.kafka.performance;
 
 import com.carrotsearch.junitbenchmarks.AbstractBenchmark;
 import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
@@ -22,8 +22,8 @@ import com.google.gson.JsonParser;
 import com.ibm.cloudant.kafka.common.InterfaceConst;
 import com.ibm.cloudant.kafka.common.utils.JavaCloudantUtil;
 import com.ibm.cloudant.kafka.connect.CloudantSinkTask;
-import com.ibm.cloudant.kakfa.connect.utils.CloudantDbUtils;
-import com.ibm.cloudant.kakfa.connect.utils.ConnectorUtils;
+import com.ibm.cloudant.kafka.connect.utils.CloudantDbUtils;
+import com.ibm.cloudant.kafka.connect.utils.ConnectorUtils;
 
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;

--- a/src/test/java/com/ibm/cloudant/kafka/performance/CloudantSourceAndSinkPerformanceTest.java
+++ b/src/test/java/com/ibm/cloudant/kafka/performance/CloudantSourceAndSinkPerformanceTest.java
@@ -11,7 +11,7 @@
  * either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-package com.ibm.cloudant.kakfa.performance;
+package com.ibm.cloudant.kafka.performance;
 
 import com.carrotsearch.junitbenchmarks.AbstractBenchmark;
 import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
@@ -24,8 +24,8 @@ import com.ibm.cloudant.kafka.connect.CloudantSinkConnector;
 import com.ibm.cloudant.kafka.connect.CloudantSinkTask;
 import com.ibm.cloudant.kafka.connect.CloudantSourceConnector;
 import com.ibm.cloudant.kafka.connect.CloudantSourceTask;
-import com.ibm.cloudant.kakfa.connect.utils.CloudantDbUtils;
-import com.ibm.cloudant.kakfa.connect.utils.ConnectorUtils;
+import com.ibm.cloudant.kafka.connect.utils.CloudantDbUtils;
+import com.ibm.cloudant.kafka.connect.utils.ConnectorUtils;
 
 import org.apache.kafka.connect.connector.ConnectorContext;
 import org.apache.kafka.connect.sink.SinkRecord;

--- a/src/test/java/com/ibm/cloudant/kafka/performance/CloudantSourcePerformanceTest.java
+++ b/src/test/java/com/ibm/cloudant/kafka/performance/CloudantSourcePerformanceTest.java
@@ -11,7 +11,7 @@
  * either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-package com.ibm.cloudant.kakfa.performance;
+package com.ibm.cloudant.kafka.performance;
 
 import com.carrotsearch.junitbenchmarks.AbstractBenchmark;
 import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
@@ -22,7 +22,7 @@ import com.ibm.cloudant.kafka.common.InterfaceConst;
 import com.ibm.cloudant.kafka.common.utils.JavaCloudantUtil;
 import com.ibm.cloudant.kafka.connect.CloudantSourceConnector;
 import com.ibm.cloudant.kafka.connect.CloudantSourceTask;
-import com.ibm.cloudant.kakfa.connect.utils.ConnectorUtils;
+import com.ibm.cloudant.kafka.connect.utils.ConnectorUtils;
 
 import org.apache.kafka.connect.connector.ConnectorContext;
 import org.apache.kafka.connect.source.SourceRecord;

--- a/src/test/java/com/ibm/cloudant/kafka/schema/JsonStructTest.java
+++ b/src/test/java/com/ibm/cloudant/kafka/schema/JsonStructTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright © 2018 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.ibm.cloudant.kafka.schema;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.FileReader;
+import java.util.List;
+import java.util.Map;
+
+public class JsonStructTest {
+
+    private static JsonObject schemaTypesObject;
+    private static Schema schemaTypesExpected = SchemaBuilder.struct()
+            .field("_id", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("_rev", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("string", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
+            .field("integer", Schema.OPTIONAL_FLOAT64_SCHEMA)
+            .field("float", Schema.OPTIONAL_FLOAT64_SCHEMA)
+            .field("long", Schema.OPTIONAL_FLOAT64_SCHEMA)
+            .field("boolean", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+            .field("null", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("array_string", SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional()
+                    .build())
+            .field("array_number", SchemaBuilder.array(Schema.OPTIONAL_FLOAT64_SCHEMA).optional()
+                    .build())
+            .field("array_boolean", SchemaBuilder.array(Schema.OPTIONAL_BOOLEAN_SCHEMA).optional
+                    ().build())
+            .field("object", SchemaBuilder.struct().field("nestedKey", Schema
+                    .OPTIONAL_STRING_SCHEMA)
+                    .optional()
+                    .build())
+            .optional()
+            .build();
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        schemaTypesObject = new Gson().fromJson(new FileReader("./src/test/resources/schema_types" +
+                ".json"), JsonObject.class);
+    }
+
+    @Test
+    public void testStringSchema() {
+        Schema result = JsonStruct.jsonElementToSchema(new JsonPrimitive("test1"));
+        assertEquals("Should get the correct schema type", Schema.Type.STRING, result.type());
+    }
+
+    @Test
+    public void testNumberSchema() {
+        Schema result = JsonStruct.jsonElementToSchema(new JsonPrimitive(1));
+        assertEquals("Should get the correct schema type", Schema.Type.FLOAT64, result.type());
+    }
+
+    @Test
+    public void testBooleanSchema() {
+        Schema result = JsonStruct.jsonElementToSchema(new JsonPrimitive(false));
+        assertEquals("Should get the correct schema type", Schema.Type.BOOLEAN, result.type());
+    }
+
+    @Test
+    public void testNullSchema() {
+        Schema result = JsonStruct.jsonElementToSchema(JsonNull.INSTANCE);
+        assertEquals("Should get the correct schema type", Schema.Type.STRING, result.type());
+        assertTrue("Should be optional", result.isOptional());
+    }
+
+    @Test
+    public void testArraySchema() {
+        JsonArray array = new JsonArray(2);
+        array.add("a");
+        array.add("b");
+        Schema result = JsonStruct.jsonElementToSchema(array);
+        Schema expectedSchema = SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional()
+                .build();
+        assertEquals("Should get the correct schema type", Schema.Type.ARRAY, result.type());
+        assertEquals("Should get the correct schema", expectedSchema, result);
+    }
+
+    @Test
+    public void testObjectSchema() {
+        JsonObject object = new JsonObject();
+        object.addProperty("aString", "testString");
+        object.addProperty("aNumber", 12);
+        Schema result = JsonStruct.jsonElementToSchema(object);
+        Schema expectedSchema = SchemaBuilder.struct()
+                .field("aString", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("aNumber", Schema.OPTIONAL_FLOAT64_SCHEMA)
+                .optional()
+                .build();
+        assertEquals("Should get the correct schema type", Schema.Type.STRUCT, result.type());
+        assertEquals("Should get the correct schema", expectedSchema, result);
+    }
+
+    @Test
+    public void testSchemaTypesObject() {
+        Schema result = JsonStruct.jsonObjectToSchema(schemaTypesObject);
+        assertEquals("Should get the correct schema type", Schema.Type.STRUCT, result.type());
+        assertEquals("Should get the correct schema", schemaTypesExpected, result);
+    }
+
+    @Test
+    public void testStructFromSchemaTypesObject() {
+        Struct result = JsonStruct.jsonObjectToStruct(schemaTypesObject, JsonStruct
+                .jsonObjectToSchema(schemaTypesObject));
+        // Perform assertions on the resulting struct
+        assertJsonObjectEqualsStruct(schemaTypesObject, result);
+    }
+
+    private void assertJsonObjectEqualsStruct(JsonObject object, Struct struct) {
+        for (Map.Entry<String, JsonElement> entry : object.entrySet()) {
+            String key = entry.getKey();
+            JsonElement element = entry.getValue();
+            assertJsonElementEqualsObject(element, struct.get(key));
+        }
+    }
+
+    private void assertJsonArrayEqualsList(JsonArray array, List list) {
+        assertEquals("There should be the same number of array elements", array.size(), list.size
+                ());
+        int index = 0;
+        for (JsonElement e : array) {
+            assertJsonElementEqualsObject(e, list.get((index)));
+            index++;
+        }
+    }
+
+    private void assertJsonElementEqualsObject(JsonElement element, Object value) {
+        if (element.isJsonNull()) {
+            assertEquals("The struct field should be null", null, value);
+        } else if (element.isJsonObject()) {
+            assertJsonObjectEqualsStruct(element.getAsJsonObject(), (Struct) value);
+        } else if (element.isJsonArray()) {
+            assertJsonArrayEqualsList(element.getAsJsonArray(), (List) value);
+        } else if (element.isJsonPrimitive()) {
+            JsonPrimitive primitive = element.getAsJsonPrimitive();
+            if (primitive.isString()) {
+                assertEquals("The struct string field should have the correct value", primitive
+                        .getAsString(), value);
+            } else if (primitive.isNumber()) {
+                assertEquals("The struct number field should have the correct value", (Double)
+                        primitive.getAsDouble(), value);
+            } else if (primitive.isBoolean()) {
+                assertEquals("The struct boolean field should have the correct value", primitive
+                        .getAsBoolean(), value);
+            } else {
+                throw new IllegalArgumentException("Unknown JSON primitive");
+            }
+        } else {
+            throw new IllegalArgumentException("Unknown JSON type");
+        }
+    }
+}

--- a/src/test/resources/schema_types.json
+++ b/src/test/resources/schema_types.json
@@ -1,0 +1,30 @@
+{
+  "_id": "00065ff1-d60f-48cc-89f0-46c8838cd49d",
+  "_rev": "2-280a5bddacae45eab509e7332fa4db3c",
+  "string": "燑홁큒ꑧ쑤∹肷켏죬㹹땀샔퀷䕽",
+  "double": 0.8394783663178513,
+  "integer": -192741966,
+  "float": 0.032276213,
+  "long": -2044357298457380400,
+  "boolean": false,
+  "null": null,
+  "array_string": [
+    "Aberystwyth",
+    "Bangor",
+    "Cardiff",
+    "Dorchester"
+  ],
+  "array_number": [
+    0.8394783663178513,
+    -192741966,
+    0.032276213,
+    -2044357298457380400
+  ],
+  "array_boolean": [
+    false,
+    true
+  ],
+  "object": {
+    "nestedKey": "㸪𞑛钽麳볬ऻ⨝쪔］猵ઘᷛ鱽"
+  }
+}

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -16,5 +16,8 @@ topics=test-topic
 # Replication Schema (default: false)
 replication=false
 
+# Original tests use the String struct
+cloudant.value.schema.struct=false
+
 #Settings for performance tests
 performance.url=https://testy-dynamite-020.cloudant.com/performance


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant-labs/kafka-connect-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant-labs/kafka-connect-cloudant/blob/master/CHANGES.md)
- [x] You have completed the PR template below:

## What

Added option to generate Struct schema with Cloudant doc messages.

## How

* Reverted to non docker pipeline build (for build stability, unrelated to the schema change)
* Fixed incorrect test package name (`kakfa` -> `kafka` unrelated to this change)
* Added option for generating Struct schema for JSON docs
    * Added config to default to existing behaviour, but allow setting of a property so message values have a generated Struct.
    * Added constants and messages for above config.
    * Added JsonStruct class for converting JsonObject to a Struct schema and building a Struct.
    * Updated source task to output Struct when option enabled.

## Testing

Added schema tests
* Default to cloudant.value.schema.struct=false for existing tests.
* Added the cloudant.value.schema.struct property to `com.ibm.cloudant.kafka.connect.CloudantSourceConnectorTest`.
* Added `com.ibm.cloudant.kafka.schema.JsonStructTest` for unit testing schema and struct generation.
* Added `com.ibm.cloudant.kafka.connect.CloudantSourceTaskTest#testStructMessage`
for real struct schema generation.

## Issues

N/A