### PR TITLE
Omit ddoc

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
  with a `org.apache.kafka.connect.data.Struct` value schema instead of as a `String`.
 - [NEW] Configuration option `cloudant.value.schema.struct.flatten` to flatten nested objects and
  arrays when using `cloudant.value.schema.struct=true`.
+ - [NEW] Configuration option `cloudant.omit.design.docs` to suppress message production for design
+ documents.
 - [BREAKING CHANGE] Changed build tooling to Gradle.
 - [NOTE] Version number format. The kafka-connect-cloudant version is no longer identical
  to an Apache Kafka version. The Apache Kafka version is appended to the kafka-cloudant-connect

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
  - [NEW] Configuration option `cloudant.omit.design.docs` to suppress message production for design
  documents.
 - [BREAKING CHANGE] Changed build tooling to Gradle.
+- [UPGRADED] Upgraded for Kafka 1.0.0
 - [NOTE] Version number format. The kafka-connect-cloudant version is no longer identical
  to an Apache Kafka version. The Apache Kafka version is appended to the kafka-cloudant-connect
  version. In this way fixes can be released into kafka-cloudant-connect independently of Apache Kafka

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ cloudant.db.username|\<username\>|YES|None|The Cloudant username to use for auth
 cloudant.db.password|\<password\>|YES|None|The Cloudant password to use for authentication.
 cloudant.db.since|1-g1AAAAETeJzLYWBgYMlgTmGQT0lKzi9..|NO|0|The first change sequence to process from the Cloudant database above. 0 will apply all available document changes.
 batch.size|400|NO|1000|The batch size used to bulk read from the Cloudant database.
+cloudant.omit.design.docs|false|NO|false| Set to true to omit design documents from the messages produced.
 cloudant.value.schema.struct|false|NO|false| _EXPERIMENTAL_ Set to true to generate a `org.apache.kafka.connect.data.Schema.Type.STRUCT` schema and send the Cloudant document payload as a `org.apache.kafka.connect.data.Struct` using the schema instead of the default of a string of the JSON document content when using the Cloudant source connector.
 cloudant.value.schema.struct.flatten|false|NO|false| _EXPERIMENTAL_ Set to true to flatten nested arrays and objects from the Cloudant document during struct generation. Only used when cloudant.value.schema.struct is true and allows processing of JSON arrays with mixed element types when using that option.
 

--- a/src/main/java/com/ibm/cloudant/kafka/common/InterfaceConst.java
+++ b/src/main/java/com/ibm/cloudant/kafka/common/InterfaceConst.java
@@ -35,6 +35,9 @@ public class InterfaceConst {
 	public final static Boolean DEFAULT_REPLICATION = false;
 	public final static String KC_SCHEMA = "kc_schema";
 
+	// Whether to omit design documents
+	public final static String OMIT_DESIGN_DOCS = "cloudant.omit.design.docs";
+
 	// Whether to use a struct schema for the message values
 	public final static String USE_VALUE_SCHEMA_STRUCT = "cloudant.value.schema.struct";
 	public final static String FLATTEN_VALUE_SCHEMA_STRUCT = "cloudant.value.schema.struct.flatten";

--- a/src/main/java/com/ibm/cloudant/kafka/common/MessageKey.java
+++ b/src/main/java/com/ibm/cloudant/kafka/common/MessageKey.java
@@ -34,6 +34,9 @@ public class MessageKey {
 	public static final String KAFKA_TOPIC_LIST_DOC = "KafkaTopicListDoc";
 	public static final String KAFKA_TOPIC_LIST_DISP = "KafkaTopicListDisp";
 
+	public static final String CLOUDANT_OMIT_DDOC_DISP = "CloudantOmitDDocDisp";
+	public static final String CLOUDANT_OMIT_DDOC_DOC = "CloudantOmitDDocDoc";
+
 	public static final String CLOUDANT_STRUCT_SCHEMA_DISP = "CloudantSchemaDisp";
 	public static final String CLOUDANT_STRUCT_SCHEMA_DOC = "CloudantSchemaDoc";
 

--- a/src/main/java/com/ibm/cloudant/kafka/connect/CloudantSourceConnectorConfig.java
+++ b/src/main/java/com/ibm/cloudant/kafka/connect/CloudantSourceConnectorConfig.java
@@ -66,6 +66,14 @@ public class CloudantSourceConnectorConfig extends AbstractConfig {
                         DATABASE_GROUP, 1, Width.LONG,
                         ResourceBundleUtil.get(MessageKey.KAFKA_TOPIC_LIST_DISP))
 
+                // Whether to omit design documents
+                .define(InterfaceConst.OMIT_DESIGN_DOCS, Type.BOOLEAN,
+                        false,
+                        Importance.LOW,
+                        ResourceBundleUtil.get(MessageKey.CLOUDANT_OMIT_DDOC_DOC),
+                        DATABASE_GROUP, 1, Width.NONE,
+                        ResourceBundleUtil.get(MessageKey.CLOUDANT_OMIT_DDOC_DISP))
+
                 // Whether to generate a struct Schema
                 .define(InterfaceConst.USE_VALUE_SCHEMA_STRUCT, Type.BOOLEAN,
                         false,

--- a/src/main/resources/message_en_US.properties
+++ b/src/main/resources/message_en_US.properties
@@ -29,6 +29,9 @@ GuidSchema = GUID Schema is unknown
 
 CloudantLimitation = Error retrieving server response
 
+CloudantOmitDDocDisp=Omit design documents
+CloudantOmitDDocDoc=True to omit design documents when generating messages.
+
 CloudantSchemaDisp = Enable struct schema generation (experimental)
 CloudantSchemaDoc = True to enable generation of a struct schema with each JSON document.\
   The struct schema will include all the fields found in the document with the following mappings:\

--- a/src/test/java/com/ibm/cloudant/kafka/connect/CloudantSourceConnectorTest.java
+++ b/src/test/java/com/ibm/cloudant/kafka/connect/CloudantSourceConnectorTest.java
@@ -100,6 +100,9 @@ public class CloudantSourceConnectorTest extends TestCase {
         Assert.assertEquals(sourceProperties.get(InterfaceConst.BATCH_SIZE), taskConfigs.get(0)
                 .get(InterfaceConst.BATCH_SIZE));
 
+        Assert.assertEquals(sourceProperties.get(InterfaceConst.OMIT_DESIGN_DOCS),
+                taskConfigs.get(0).get(InterfaceConst.OMIT_DESIGN_DOCS));
+
         Assert.assertEquals(sourceProperties.get(InterfaceConst.USE_VALUE_SCHEMA_STRUCT),
                 taskConfigs.get(0).get(InterfaceConst.USE_VALUE_SCHEMA_STRUCT));
         Assert.assertEquals(sourceProperties.get(InterfaceConst.FLATTEN_VALUE_SCHEMA_STRUCT),

--- a/src/test/java/com/ibm/cloudant/kafka/connect/utils/ConnectorUtils.java
+++ b/src/test/java/com/ibm/cloudant/kafka/connect/utils/ConnectorUtils.java
@@ -60,6 +60,10 @@ public class ConnectorUtils {
         sourceProperties.put(InterfaceConst.LAST_CHANGE_SEQ, testProperties.getProperty
                 (InterfaceConst.LAST_CHANGE_SEQ));
 
+        // Whether to omit design documents
+        sourceProperties.put(InterfaceConst.OMIT_DESIGN_DOCS, testProperties.getProperty
+                (InterfaceConst.OMIT_DESIGN_DOCS));
+
         // Schema options
         sourceProperties.put(InterfaceConst.USE_VALUE_SCHEMA_STRUCT, testProperties
                 .getProperty(InterfaceConst.USE_VALUE_SCHEMA_STRUCT));

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -16,6 +16,8 @@ topics=test-topic
 # Replication Schema (default: false)
 replication=false
 
+cloudant.omit.design.docs=false
+
 # Original tests use the String struct, no flattening
 cloudant.value.schema.struct=false
 cloudant.value.schema.struct.flatten=false


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant-labs/kafka-connect-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant-labs/kafka-connect-cloudant/blob/master/CHANGES.md)
- [x] You have completed the PR template below:

## What

Added `cloudant.omit.design.docs` option

## How

Check a boolean flag and whether the ID starts with `_design/` before producing the message.
Updated associated docs and messages.

Unrelated commit to add a previously missing entry to `CHANGES.md`.

## Testing

Added option to `test.properties` and the `ConnectorUtils` source properties and new assertion to `com.ibm.cloudant.kafka.connect.CloudantSourceConnectorTest#testTaskConfigs`.
Added new test `com.ibm.cloudant.kafka.connect.CloudantSourceTaskTest#testOmitDesignDoc`.

## Issues

N/A
