### PR TITLE
Updated connector reported version number

### DIFF
--- a/src/main/java/com/ibm/cloudant/kafka/common/utils/JavaCloudantUtil.java
+++ b/src/main/java/com/ibm/cloudant/kafka/common/utils/JavaCloudantUtil.java
@@ -27,17 +27,37 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 
 public class JavaCloudantUtil {
 
+	public static final String VERSION;
+
+	private static final String PROPS_FILE = "META-INF/com.ibm.cloudant.kafka.client.properties";
 	private static final UserAgentInterceptor UA_INTERCEPTOR = new UserAgentInterceptor
-			(JavaCloudantUtil.class.getClassLoader(), "META-INF/com.ibm.cloudant.kafka.client.properties");
+			(JavaCloudantUtil.class.getClassLoader(), PROPS_FILE);
 	private static Logger LOG = Logger.getLogger(JavaCloudantUtil.class.toString());
-	
+
+	static {
+		String v = "UNKNOWN";
+		Properties p = new Properties();
+		try(InputStream is = JavaCloudantUtil.class.getResourceAsStream(PROPS_FILE)) {
+			if (is != null) {
+				p.load(is);
+				v = p.getProperty("user.agent.version", "UNKNOWN");
+			}
+		} catch(IOException e) {
+			LOG.warn(PROPS_FILE, e);
+		}
+		VERSION = v;
+	}
+
 	public static JSONArray batchWrite(String url, String userName, String password, JSONArray data) throws JSONException {
 		LOG.debug(data.toString());
 		// wrap result to JSONArray

--- a/src/main/java/com/ibm/cloudant/kafka/connect/CloudantSinkConnector.java
+++ b/src/main/java/com/ibm/cloudant/kafka/connect/CloudantSinkConnector.java
@@ -1,35 +1,33 @@
-/*******************************************************************************
-* Copyright (c) 2016 IBM Corp.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*******************************************************************************/
+/*
+ * Copyright © 2016, 2018 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
 package com.ibm.cloudant.kafka.connect;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import com.ibm.cloudant.kafka.common.InterfaceConst;
+import com.ibm.cloudant.kafka.common.MessageKey;
+import com.ibm.cloudant.kafka.common.utils.JavaCloudantUtil;
+import com.ibm.cloudant.kafka.common.utils.ResourceBundleUtil;
 
 import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkConnector;
 import org.apache.log4j.Logger;
 
-import com.ibm.cloudant.kafka.common.InterfaceConst;
-import com.ibm.cloudant.kafka.common.MessageKey;
-import com.ibm.cloudant.kafka.common.utils.ResourceBundleUtil;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class CloudantSinkConnector extends SinkConnector {
 
@@ -46,7 +44,7 @@ public class CloudantSinkConnector extends SinkConnector {
 	
 	@Override
 	public String version() {
-		return AppInfoParser.getVersion();
+		return JavaCloudantUtil.VERSION;
 	}
 
 	@Override

--- a/src/main/java/com/ibm/cloudant/kafka/connect/CloudantSourceConnector.java
+++ b/src/main/java/com/ibm/cloudant/kafka/connect/CloudantSourceConnector.java
@@ -1,35 +1,33 @@
-/*******************************************************************************
-* Copyright (c) 2016 IBM Corp.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*******************************************************************************/
+/*
+ * Copyright © 2016, 2018 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
 package com.ibm.cloudant.kafka.connect;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import com.ibm.cloudant.kafka.common.InterfaceConst;
+import com.ibm.cloudant.kafka.common.MessageKey;
+import com.ibm.cloudant.kafka.common.utils.JavaCloudantUtil;
+import com.ibm.cloudant.kafka.common.utils.ResourceBundleUtil;
 
 import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceConnector;
 import org.apache.log4j.Logger;
 
-import com.ibm.cloudant.kafka.common.InterfaceConst;
-import com.ibm.cloudant.kafka.common.MessageKey;
-import com.ibm.cloudant.kafka.common.utils.ResourceBundleUtil;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class CloudantSourceConnector extends SourceConnector {
 	
@@ -89,6 +87,6 @@ public class CloudantSourceConnector extends SourceConnector {
 	
 	@Override
 	public String version() {
-		return AppInfoParser.getVersion();
+		return JavaCloudantUtil.VERSION;
 	}
 }


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant-labs/kafka-connect-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes - manually tested
- [x] You have updated the [CHANGES.md](https://github.com/cloudant-labs/kafka-connect-cloudant/blob/master/CHANGES.md) - *Covered by existing version note*
- [x] You have completed the PR template below:

## What

Updated connector reported version number

## How

Stopped returning the Kafka version and instead use a constant initialized from the connector's own properties file generated at build time.

## Testing

Checked output from built jar:
>[2018-03-15 13:52:07,402] INFO Instantiated connector cdt-kafka-example with version 0.100.0-SNAPSHOT-kafka-1.0.0 of type class com.ibm.cloudant.kafka.connect.CloudantSourceConnector (org.apache.kafka.connect.runtime.Worker:208)

## Issues

N/A
