### PR TITLE
Stopped fields being shared between configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,7 @@ jdk:
 - oraclejdk8
 
 ##########################
-### SET PARAMETERS
-##########################
-before_script:
-  - sed -ie 's/examples/'"$CLOUDANT_ACCOUNT"'/g' src/test/resources/test.properties
-  - sed -ie 's/animaldb/'"$CLOUDANT_DB"'/g' src/test/resources/test.properties
-  - sed -ie 's/testuser/'"$CLOUDANT_USERNAME"'/g' src/test/resources/test.properties
-  - sed -ie 's/testpassword/'"$CLOUDANT_PASSWORD"'/g' src/test/resources/test.properties
-##########################
 ### BUILD WITH GRADLE
 ##########################
 script:
-- ./gradlew test
+- ./gradlew -Dcloudant.account=https://$CLOUDANT_ACCOUNT.cloudant.com -Dcloudant.user=$CLOUDANT_USERNAME -Dcloudant.pass=$CLOUDANT_PASSWORD test

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- [FIXED] Issue where multiple source connector configurations overlapped causing incorrect message
+ publication or duplication.
+
 # 0.100.1-kafka-1.0.0 (2018-03-19)
 
 - [FIXED] Corrected version number reported by the source and sink connectors and tasks.

--- a/src/main/java/com/ibm/cloudant/kafka/common/utils/JavaCloudantUtil.java
+++ b/src/main/java/com/ibm/cloudant/kafka/common/utils/JavaCloudantUtil.java
@@ -60,7 +60,6 @@ public class JavaCloudantUtil {
 	}
 
 	public static JSONArray batchWrite(String url, String userName, String password, JSONArray data) throws JSONException {
-		LOG.debug(data.toString());
 		// wrap result to JSONArray
 		JSONArray result = new JSONArray();
 		

--- a/src/main/java/com/ibm/cloudant/kafka/connect/CloudantSourceTask.java
+++ b/src/main/java/com/ibm/cloudant/kafka/connect/CloudantSourceTask.java
@@ -43,9 +43,9 @@ public class CloudantSourceTask extends SourceTask {
 
     private static Logger LOG = Logger.getLogger(CloudantSourceTask.class);
 
-    private static long FEED_SLEEP_MILLISEC = 5000;
-    private static long SHUTDOWN_DELAY_MILLISEC = 10;
-    private static String DEFAULT_CLOUDANT_LAST_SEQ = "0";
+    private static final long FEED_SLEEP_MILLISEC = 5000;
+    private static final long SHUTDOWN_DELAY_MILLISEC = 10;
+    private static final String DEFAULT_CLOUDANT_LAST_SEQ = "0";
 
     private AtomicBoolean stop;
     private AtomicBoolean _running;
@@ -56,10 +56,10 @@ public class CloudantSourceTask extends SourceTask {
     private boolean flattenStructSchema = false;
     private boolean omitDesignDocs = false;
 
-    private static String latestSequenceNumber = null;
-    private static int batch_size = 0;
+    private String latestSequenceNumber = null;
+    private int batch_size = 0;
 
-    private static Database cloudantDb = null;
+    private Database cloudantDb = null;
 
     @Override
     public List<SourceRecord> poll() throws InterruptedException {


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant-labs/kafka-connect-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant-labs/kafka-connect-cloudant/blob/master/CHANGES.md)
- [x] You have completed the PR template below:

## What

Stopped some configuration being shared between instances.

## How

Some fields are configured per connector instance config and should not be `static` in `CloudantSourceTask`:
* `lastSequenceNumber`
* `batch_size`
* `cloudantDb`

## Testing

Added
`com.ibm.cloudant.kafka.connect.CloudantSourceTaskTest#testMultipleConnectorInstances`

## Issues

Fixes #39 
