### PR TITLE
Fix README

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# UNRELEASED
+- [FIXED] README to align with the 2.8.0 Kafka version.
+
 # 0.100.2-kafka-1.0.0 (2018-04-13)
 
 - [FIXED] Issue where multiple source connector configurations overlapped causing incorrect message

--- a/README.md
+++ b/README.md
@@ -16,9 +16,12 @@ Experimental
 
 ## Configuration
 
-The Cloudant Kafka connector can be configured in standalone or distributed mode according to the [Kafka Connector documentation](http://docs.confluent.io/3.0.1/connect/userguide.html#configuring-connectors).
+The Cloudant Kafka connector can be configured in standalone or distributed mode according to 
+the [Kafka Connector documentation](http://docs.confluent.io/3.0.1/connect/userguide.html#configuring-connectors). At a minimum it is necessary to configure:
 
-Make sure to include the following values for either configuration:
+1. `bootstrap.servers`
+2. If using a standalone worker `offset.storage.file.filename`.
+3. The following configuration when using the Cloudant connector as either a source or a sink:
 
 Parameter | Value
 ---:|:---
@@ -87,26 +90,26 @@ For example:
 - standalone execution with Cloudant as source:
 
   ```
-  $kafka_home/bin/connect-standalone connect-standalone.properties connect-cloudant-source.properties`
+  $kafka_home/bin/connect-standalone.sh connect-standalone.properties connect-cloudant-source.properties
   ```
 
 - standalone execution with Cloudant as sink:
 
   ```
-  $kafka_home/bin/connect-standalone connect-standalone.properties connect-cloudant-sink.properties
+  $kafka_home/bin/connect-standalone.sh connect-standalone.properties connect-cloudant-sink.properties
   ```
 
 - standalone execution with multiple configurations, one using Cloudant as source and one using Cloudant as sink:
 
   ```
-  $kafka_home/bin/connect-standalone connect-standalone.properties connect-cloudant-source.properties connect-cloudant-sink.properties
+  $kafka_home/bin/connect-standalone.sh connect-standalone.properties connect-cloudant-source.properties connect-cloudant-sink.properties
   ```
 
 Any number of connector configurations can be passed to the executing script.
 
 INFO level logging is configured by default to the console. To change log levels or settings, work with
 
-`$kafka_home/etc/kafka/connect-log4j.properties`
+`$kafka_home/config/connect-log4j.properties`
 
 and add log settings like
 


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

I fixed the README to align with the 2.8.0 Kafka version.

## Approach

* `offset.storage.file.filename` and `bootstrap.servers` are now required properties in the `connect-standalone.properties` or `connect-distributed.properties` files, so I added them.
* I extended the commands with the `.sh` extension.
* `connect-log4j.properties` file takes place in the `$kafka_home/config` directory.

## Schema & API Changes

No change

## Security and Privacy

No change

## Testing

No tests. Actually I tested manually the README with the latest Kafka.

## Monitoring and Logging

No change