### PR TITLE
53: Fix publishing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ stage('Publish') {
 
             // Upload using the ossrh creds (upload destination logic is in build.gradle)
             withCredentials([usernamePassword(credentialsId: 'ossrh-creds', passwordVariable: 'OSSRH_PASSWORD', usernameVariable: 'OSSRH_USER'), usernamePassword(credentialsId: 'signing-creds', passwordVariable: 'KEY_PASSWORD', usernameVariable: 'KEY_ID'), file(credentialsId: 'signing-key', variable: 'SIGNING_FILE')]) {
-                sh './gradlew -Dsigning.keyId=$KEY_ID -Dsigning.password=$KEY_PASSWORD -Dsigning.secretKeyRingFile=$SIGNING_FILE -DossrhUsername=$OSSRH_USER -DossrhPassword=$OSSRH_PASSWORD upload'
+                sh './gradlew -Dsigning.keyId=$KEY_ID -Dsigning.password=$KEY_PASSWORD -Dsigning.secretKeyRingFile=$SIGNING_FILE -DossrhUsername=$OSSRH_USER -DossrhPassword=$OSSRH_PASSWORD publish'
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -149,67 +149,6 @@ artifacts {
     }
 }
 
-signing {
-    // Only apply signing when it is a release and is being published
-    required {
-        isReleaseVersion && gradle.taskGraph.hasTask("uploadArchives")
-    }
-    // When signing, sign the archives
-    sign configurations.archives
-}
-
-//uploadArchives {
-//    repositories {
-//        mavenDeployer {
-//
-//            // When publishing sign the pom
-//            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-//
-//            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-//                authentication(userName: ossrhUsername, password: ossrhPassword)
-//            }
-//
-//            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-//                authentication(userName: ossrhUsername, password: ossrhPassword)
-//            }
-//
-//            // Augment the pom with additional information
-//            pom.project {
-//                name project.name
-//                packaging 'jar'
-//                url 'https://cloudant.com'
-//                description 'Apache Kafka Connect API connector for Cloudant'
-//                inceptionYear '2016'
-//                licenses {
-//                    license {
-//                        name 'The Apache Software License, Version 2.0'
-//                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-//                        distribution 'repo'
-//                    }
-//                }
-//                scm {
-//                    connection 'scm:git:git@github.com:cloudant-labs/kafka-connect-cloudant.git'
-//                    developerConnection 'scm:git:git@github.com:cloudant-labs/kafka-connect-cloudant.git'
-//                    url 'scm:git:git@github.com:cloudant-labs/kafka-connect-cloudant.git'
-//                    tag 'preview'
-//                }
-//                properties {
-//                    'project.build.sourceEncoding' 'UTF-8'
-//                }
-//                developers {
-//                    developer {
-//                        name 'IBM Cloudant'
-//                        email 'cldtsdks@us.ibm.com'
-//                        url 'https://cloudant.com'
-//                        organization 'IBM'
-//                        organizationUrl 'http://www.ibm.com'
-//                    }
-//                }
-//            }
-//        }
-//    }
-//}
-
 test {
     // Exclude the performance tests
     exclude 'com/ibm/cloudant/kafka/performance/**'
@@ -220,4 +159,64 @@ tasks.withType(Test) {
     systemProperties = System.getProperties()
     // Make sure it is UTF-8 for tests
     systemProperty "file.encoding", "UTF-8"
+}
+
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+            pom {
+                name = project.name
+                packaging = 'jar'
+                url = 'https://cloudant.com'
+                description = 'Apache Kafka Connect API connector for Cloudant'
+                inceptionYear = '2016'
+                licenses {
+                    license {
+                        name = 'The Apache Software License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        distribution = 'repo'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:git@github.com:cloudant-labs/kafka-connect-cloudant.git'
+                    developerConnection = 'scm:git:git@github.com:cloudant-labs/kafka-connect-cloudant.git'
+                    url = 'scm:git:git@github.com:cloudant-labs/kafka-connect-cloudant.git'
+                    tag = 'preview'
+                }
+                developers {
+                    developer {
+                        name = 'IBM Cloudant'
+                        email = 'cldtsdks@us.ibm.com'
+                        url = 'https://cloudant.com'
+                        organization = 'IBM'
+                        organizationUrl = 'http://www.ibm.com'
+                    }
+                }
+            }
+        }
+    }
+
+    // Only sign release versions
+    tasks.withType(Sign) {
+        onlyIf { isReleaseVersion }
+    }
+
+    signing {
+        // When signing, sign the archives
+        sign publishing.publications.mavenJava
+    }
+
+    repositories {
+        maven {
+            url = version.endsWith('SNAPSHOT') ?
+                "https://oss.sonatype.org/content/repositories/snapshots" :
+                "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+            credentials(PasswordCredentials) {
+                username = ossrhUsername
+                password = ossrhPassword
+            }
+        }
+    }
 }


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Fix publishing to use the new gradle model. NB this is now achieved by the `publish` task.

## Approach

Remove and rewrite `uploadArchives` task per advice [here](https://docs.gradle.org/current/userguide/upgrading_version_5.html#legacy_publication_system_is_deprecated_and_replaced_with_the_publish_plugins)

## Schema & API Changes

No change

## Security and Privacy

No change

## Testing

Tested locally up to point of actually publishing assets, ie
```
./gradlew -i -Dsigning.secretKeyRingFile=/home/tomblench/.gnupg/secring.gpg -Dsigning.password=test -Dsigning.keyId=xxx -DossrhUsername=fake -DossrhPassword=fake clean publish
```
Observed that files are output to correct locations, and `publishMavenJavaPublicationToMavenRepository` step fails as expected `Received status code 401 from server: Unauthorized`.

## Monitoring and Logging

No change
